### PR TITLE
changed jetty versions to latest stable

### DIFF
--- a/jersey/pom.xml
+++ b/jersey/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <jettyVersion>9.4.25.v20191220</jettyVersion>
+        <jettyVersion>9.4.36.v20210114</jettyVersion>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
     </properties>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <jettyVersion>9.4.25.v20191220</jettyVersion>
+        <jettyVersion>9.4.36.v20210114</jettyVersion>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
     </properties>


### PR DESCRIPTION
Поменял на последнюю стабильную из 9х, правда не совсем понял, почему 9, если мы под 11 java, то можно перейти на jetty 10 или 11? Подумал, что может в этом есть глубокий смысл.